### PR TITLE
bump graphql plugin version

### DIFF
--- a/template.json
+++ b/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "mime-types": "^2.1.27",
-      "strapi-plugin-graphql": "3.2.5"
+      "strapi-plugin-graphql": "3.5.2"
     }
   }
 }


### PR DESCRIPTION
The plugin was not installing correctly, I noticed when I installed locally the version is 3.5.2