### PR TITLE
Make the graphql version dynamic

### DIFF
--- a/template.js
+++ b/template.js
@@ -1,0 +1,10 @@
+module.exports = function(scope) {
+  return {
+    package: {
+      dependencies: {
+        "mime-types": "^2.1.27",
+        "strapi-plugin-graphql": scope.strapiVersion,
+      }
+    }
+  }
+}

--- a/template.json
+++ b/template.json
@@ -1,8 +1,0 @@
-{
-  "package": {
-    "dependencies": {
-      "mime-types": "^2.1.27",
-      "strapi-plugin-graphql": "3.5.2"
-    }
-  }
-}


### PR DESCRIPTION
Make the graphql plugin version dynamic, so we don't have to keep it in sync manually. From the [docs](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/installation/templates.html#file-structure)