### PR TITLE
Fix mongodb seeding error

### DIFF
--- a/template/config/functions/bootstrap.js
+++ b/template/config/functions/bootstrap.js
@@ -8,7 +8,7 @@ const {
   homepage,
   writers,
   articles,
-  global
+  global,
 } = require("../../data/data.json");
 
 async function isFirstRun() {
@@ -20,7 +20,7 @@ async function isFirstRun() {
   const initHasRun = await pluginStore.get({ key: "initHasRun" });
   await pluginStore.set({ key: "initHasRun", value: true });
   return !initHasRun;
-};
+}
 
 async function setPublicPermissions(newPermissions) {
   // Find the ID of the public role
@@ -53,7 +53,7 @@ async function setPublicPermissions(newPermissions) {
       // Enable the selected permissions
       return strapi
         .query("permission", "users-permissions")
-        .update({ id: permission.id }, { enabled: true })
+        .update({ id: permission.id }, { enabled: true });
     });
   await Promise.all(updatePromises);
 }
@@ -62,7 +62,7 @@ function getFileSizeInBytes(filePath) {
   const stats = fs.statSync(filePath);
   const fileSizeInBytes = stats["size"];
   return fileSizeInBytes;
-};
+}
 
 function getFileData(fileName) {
   const filePath = `./data/uploads/${fileName}`;
@@ -77,7 +77,7 @@ function getFileData(fileName) {
     name: fileName,
     size,
     type: mimeType,
-  }
+  };
 }
 
 // Create an entry and attach files if there are any
@@ -90,14 +90,16 @@ async function createEntry({ model, entry, files }) {
       });
     }
   } catch (e) {
-    console.log('model', entry, e);
+    console.log("model", entry, e);
   }
 }
 
 async function importCategories() {
-  return Promise.all(categories.map((category) => {
-    return createEntry({ model: "category", entry: category });
-  }));
+  return Promise.all(
+    categories.map((category) => {
+      return createEntry({ model: "category", entry: category });
+    })
+  );
 }
 
 async function importHomepage() {
@@ -108,30 +110,69 @@ async function importHomepage() {
 }
 
 async function importWriters() {
-  return Promise.all(writers.map(async (writer) => {
-    const files = {
-      picture: getFileData(`${writer.email}.jpg`),
+  return Promise.all(
+    writers.map(async (writer) => {
+      const files = {
+        picture: getFileData(`${writer.email}.jpg`),
+      };
+      return createEntry({
+        model: "writer",
+        entry: writer,
+        files,
+      });
+    })
+  );
+}
+
+// Randomly set relations on Article to avoid error with MongoDB
+function getEntryWithRelations(article, categories, authors) {
+  const isMongoose = strapi.config.connections.default.connector == "mongoose";
+
+  if (isMongoose) {
+    const randomRelation = (relation) =>
+      relation[Math.floor(Math.random() * relation.length)].id;
+    delete article.category.id;
+    delete article.author.id;
+
+    return {
+      ...article,
+      category: {
+        _id: randomRelation(categories),
+      },
+      author: {
+        _id: randomRelation(authors),
+      },
     };
-    return createEntry({
-      model: "writer",
-      entry: writer,
-      files,
-    });
-  }));
+  }
+
+  return article;
 }
 
 async function importArticles() {
-  return Promise.all(articles.map((article) => {
-    const files = {
-      image: getFileData(`${article.slug}.jpg`),
-    };
-    return createEntry({ model: "article", entry: article, files });
-  }));
+  const categories = await strapi.query("category").find();
+  const authors = await strapi.query("writer").find();
+
+  return Promise.all(
+    articles.map((article) => {
+      // Get relations for each article
+      const entry = getEntryWithRelations(article, categories, authors);
+
+      const files = {
+        image: getFileData(`${article.slug}.jpg`),
+      };
+
+      return createEntry({
+        model: "article",
+        entry,
+        files,
+      });
+    })
+  );
 }
 
 async function importGlobal() {
   const files = {
-    "favicon": getFileData("favicon.png"),
+    favicon: getFileData("favicon.png"),
     "defaultSeo.shareImage": getFileData("default-image.png"),
   };
   return createEntry({ model: "global", entry: global, files });
@@ -140,11 +181,11 @@ async function importGlobal() {
 async function importSeedData() {
   // Allow read of application content types
   await setPublicPermissions({
-    global: ['find'],
-    homepage: ['find'],
-    article: ['find', 'findone'],
-    category: ['find', 'findone'],
-    writer: ['find', 'findone'],
+    global: ["find"],
+    homepage: ["find"],
+    article: ["find", "findone"],
+    category: ["find", "findone"],
+    writer: ["find", "findone"],
   });
 
   // Create all entries
@@ -160,11 +201,11 @@ module.exports = async () => {
 
   if (shouldImportSeedData) {
     try {
-      console.log('Setting up the template...');
+      console.log("Setting up the template...");
       await importSeedData();
-      console.log('Ready to go');
+      console.log("Ready to go");
     } catch (error) {
-      console.log('Could not import seed data');
+      console.log("Could not import seed data");
       console.error(error);
     }
   }

--- a/template/data/data.json
+++ b/template/data/data.json
@@ -85,7 +85,7 @@
     },
     {
       "title": "A bug is becoming a meme on the internet",
-      "content": "It's the story of a user named **Omer Barnir** who reported a bug in 2005 on the MySQL [bug report platform](https://bugs.mysql.com/)\n\nBut the thing is that Omer never get an answer. 15 years later, the bug has never been fix and people are starting to make fun out of it. We let you take a look at the conversation [here](https://bugs.mysql.com/bug.php?id=11472), it's pretty funny",
+      "content": "It's the story of a user named **Omer Barnir** who reported a bug in 2005 on the MySQL [bug report platform](https://bugs.mysql.com/)\n\nBut the thing is that Omer never got an answer. 15 years later, the bug has never been fix and people are starting to make fun out of it. We let you take a look at the conversation [here](https://bugs.mysql.com/bug.php?id=11472), it's pretty funny",
       "slug": "a-bug-is-becoming-a-meme-on-the-internet",
       "category": {
         "id": 2


### PR DESCRIPTION
This is maybe not the best solution but a workaround that avoids an error when using mongodb.

- Relations are set randomly in the bootstrap function using `_id` for mongodb and `id` for sql databases

closes #5 , closes #7